### PR TITLE
Fixed clientId handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
   - 5.4
+  - 7.0
 before_script: composer install
 script: vendor/bin/phpunit

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -99,10 +99,10 @@ class Auth {
     public function authorise( $tokenParams = array(), $authOptions = array(), $force = false ) {
 
         if ( !empty( $tokenParams ) ) {
-            $this->defaultAuthoriseTokenParams = $tokenParams;
+            $this->defaultAuthoriseTokenParams = array_merge( $this->defaultAuthoriseTokenParams, $tokenParams );
         }
         if ( !empty( $authOptions ) ) {
-            $this->defaultAuthoriseAuthOptions = $authOptions;
+            $this->defaultAuthoriseAuthOptions = array_merge( $this->defaultAuthoriseAuthOptions, $authOptions );
         }
         
         if ( !$force && !empty( $this->tokenDetails ) ) {

--- a/tests/AppStatsTest.php
+++ b/tests/AppStatsTest.php
@@ -62,7 +62,6 @@ class AppStatsTest extends \PHPUnit_Framework_TestCase {
     }
 
     public static function tearDownAfterClass() {
-        // echo 'The appId was: '.self::$testApp->getAppKeyDefault()->string."\n";
         self::$testApp->release();
     }
 

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -237,9 +237,9 @@ class AuthTest extends \PHPUnit_Framework_TestCase {
     public function testTokenRequestWithAuthUrlParams() {
         $headers = array( 'Test header: yes', 'Another one: no' );
         $authParams = array( 'param1' => 'value1', 'test' => 1, 'ttl' => 720000 );
-        $overridenTokenParams = array( 'ttl' => 360000 );
+        $overriddenTokenParams = array( 'ttl' => 360000 );
         // authParams and tokenParams should be merged
-        // `ttl` should be overwritten by $overridenTokenParams
+        // `ttl` should be overwritten by $overriddenTokenParams
         $expectedAuthParams = array( 'param1' => 'value1', 'test' => 1, 'ttl' => 360000 );
         $method = 'POST';
 
@@ -251,23 +251,23 @@ class AuthTest extends \PHPUnit_Framework_TestCase {
             'httpClass' => 'authTest\HttpMock',
         ) ) );
         
-        $ably->auth->requestToken( $overridenTokenParams );
+        $ably->auth->requestToken( $overriddenTokenParams );
         
         $this->assertTrue( is_a( $ably->http, '\authTest\HttpMock' ) , 'Expected HttpMock class to be used' );
         $this->assertEquals( $headers, $ably->http->headers, 'Expected authHeaders to match' );
         $this->assertEquals( $expectedAuthParams, $ably->http->params, 'Expected authParams to match' );
         $this->assertEquals( $method, $ably->http->method, 'Expected authMethod to match' );
 
-        $overridenAuthParams = array(
+        $overriddenAuthParams = array(
             'authHeaders' => array( 'CompletelyNewHeaders: true' ),
             'authParams' => array( 'completelyNewParams' => 'yes' ),
         );
         $expectedAuthParams = array( 'completelyNewParams' => 'yes', 'ttl' => 360000 );
         $forceReauth = true;
 
-        $ably->auth->requestToken( $overridenTokenParams, $overridenAuthParams );
+        $ably->auth->requestToken( $overriddenTokenParams, $overriddenAuthParams );
 
-        $this->assertEquals( $overridenAuthParams['authHeaders'], $ably->http->headers, 'Expected authHeaders to be completely replaced' );
+        $this->assertEquals( $overriddenAuthParams['authHeaders'], $ably->http->headers, 'Expected authHeaders to be completely replaced' );
         $this->assertEquals( $expectedAuthParams, $ably->http->params, 'Expected authParams to be completely replaced' );
     }
 
@@ -468,14 +468,14 @@ class AuthTest extends \PHPUnit_Framework_TestCase {
         $token1 = $ably->auth->authorise(array(
             'ttl' => 10000,
         ), array(
-            'clientId' => 'overridenClientId',
+            'clientId' => 'overriddenClientId',
         ));
 
         $forceReauth = true;
         $token2 = $ably->auth->authorise( array(), array(), $forceReauth );
 
         $this->assertFalse( $token1 == $token2, 'Expected different tokens to be issued') ;
-        $this->assertEquals( 'overridenClientId', $ably->auth->clientId, 'Expected to use a new clientId as a default' );
+        $this->assertEquals( 'overriddenClientId', $ably->auth->clientId, 'Expected to use a new clientId as a default' );
         $this->assertLessThan( $ably->systemTime() + 20000, $token2->expires, 'Expected to use a new ttl as a default' );
     }
 

--- a/tests/ClientIdTest.php
+++ b/tests/ClientIdTest.php
@@ -189,24 +189,22 @@ class ClientIdTest extends \PHPUnit_Framework_TestCase {
      * the ClientOptions#clientId takes precendence and is used for all Auth operations 
      */
     public function testClientIdPrecedence() {
-        $clientId = 'testClientId';
-
         $ablyCId = new AblyRest( array_merge( self::$defaultOptions, array(
             'key' => self::$testApp->getAppKeyDefault()->string,
             'useTokenAuth' => true,
-            'clientId' => 'testClientId',
+            'clientId' => 'overriddenClientId',
             'defaultTokenParams' => new TokenParams( array(
-                'clientId' => 'overridenClientId',
+                'clientId' => 'tokenParamsClientId',
             ) ),
         ) ) );
 
         $ablyCId->auth->authorise(); // obtain a token
-        $this->assertEquals( 'overridenClientId', $ablyCId->auth->clientId, 'Expected defaultTokenParams to override provided clientId' );
+        $this->assertEquals( 'overriddenClientId', $ablyCId->auth->clientId, 'Expected defaultTokenParams to override provided clientId' );
 
         $channel = $ablyCId->channels->get( 'persisted:testClientIdPrecedence' );
         $channel->publish( 'testEvent', 'testData' );
 
-        $this->assertEquals( 'overridenClientId', $channel->history()->items[0]->clientId, 'Expected message clientId to match' );
+        $this->assertEquals( 'overriddenClientId', $channel->history()->items[0]->clientId, 'Expected message clientId to match' );
     }
 
     /**


### PR DESCRIPTION
This PR fixed clientId precedence in Auth, remembering of params in Auth::authorise(), cleans up parts of code and adds PHP 7 to Travis build file