### PR TITLE
Moved `force` parameter out of authorise() to AuthOptions

### DIFF
--- a/src/AblyRest.php
+++ b/src/AblyRest.php
@@ -153,7 +153,7 @@ class AblyRest {
                 && $e->getCode() == 40140;
 
             if ( $causedByExpiredToken ) { // renew the token
-                $this->auth->authorise( array(), array(), $force = true );
+                $this->auth->authorise( array(), array( 'force' => true ) );
                 
                 // merge headers now and use auth = false to prevent potential endless recursion
                 $mergedHeaders = array_merge( $this->auth->getAuthHeaders(), $headers );

--- a/src/Models/AuthOptions.php
+++ b/src/Models/AuthOptions.php
@@ -75,6 +75,11 @@ class AuthOptions extends BaseOptions {
      */
     public $queryTime;
 
+    /**
+     * @var boolean Forces a token renewal when calling Auth::authorise()
+     */
+    public $force;
+
     public function __construct( $options = array() ) {
         parent::__construct( $options );
         

--- a/tests/ClientIdTest.php
+++ b/tests/ClientIdTest.php
@@ -108,7 +108,7 @@ class ClientIdTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals( 'overriddenClientId_authOptions', $ablyCid->auth->clientId );
 
         // test clientId overridden by tokenParams
-        $ablyCid->auth->authorise( array( 'clientId' => 'overriddenClientId_tokenParams' ), array(), $force = true );
+        $ablyCid->auth->authorise( array( 'clientId' => 'overriddenClientId_tokenParams' ), array( 'force' => true ) );
         $this->assertEquals( 'overriddenClientId_tokenParams', $ablyCid->auth->clientId );
     }
 

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -162,6 +162,7 @@ class TypesTest extends \PHPUnit_Framework_TestCase {
             'authHeaders',
             'authParams',
             'queryTime',
+            'force',
         ) );
     }
 


### PR DESCRIPTION
This PR fixes https://github.com/ably/ably-php/issues/23