### PR TITLE
Fixes relative path creation issue in PaginatedResult@parsePaginationHeaders

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["messaging", "messages", "ably"],
     "homepage": "https://www.ably.io/",
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "ext-json" : "*",
         "ext-curl" : "*",
         "ext-openssl" : "*"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["messaging", "messages", "ably"],
     "homepage": "https://www.ably.io/",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.5 || ^7.0",
         "ext-json" : "*",
         "ext-curl" : "*",
         "ext-openssl" : "*"

--- a/src/Models/PaginatedResult.php
+++ b/src/Models/PaginatedResult.php
@@ -157,7 +157,11 @@ class PaginatedResult {
                 throw new AblyException( "Server error - only relative URLs are supported in pagination" );
             }
 
-            $this->paginationHeaders[$rel] = $path.substr($link, 2);
+            // attempts to fix incorrectly built relative paths.. 
+            // '/push/' no longer becomes '/push/push'
+            $path = $path . str_replace( $path, '', substr($link, 1) );
+
+            $this->paginationHeaders[$rel] = $path;
         }
     }
 }


### PR DESCRIPTION
Consuming the following pagination request I received API path errros..
    
```
$pushAdmin = $client->push->admin;
$page = $pushAdmin->deviceRegistrations->list_([ 'limit' => 10 ]);
if( $page->hasNext() ){
    $page->next();
}
```
    
Inspecting the $path passed to requestInternal showed me that /push was becoming /push/push
    
- modified:   src/Models/PaginatedResult.php