### PR TITLE
Fix parsePaginationHeaders

### DIFF
--- a/src/Models/PaginatedResult.php
+++ b/src/Models/PaginatedResult.php
@@ -143,7 +143,7 @@ class PaginatedResult {
 
         $path = preg_replace('/\/[^\/]*$/', '/', $this->path);
 
-        preg_match_all('/Link: *\<([^\>]*)\>; *rel="([^"]*)"/', $headers, $matches, PREG_SET_ORDER);
+        preg_match_all('/Link: *\<([^\>]*)\>; *rel="([^"]*)"/i', $headers, $matches, PREG_SET_ORDER);
 
         if (!$matches) return;
 


### PR DESCRIPTION
Fixes issue #92

Errors found when running the tests locally:

```
  1) tests\AppStatsTest::testAppstatsPagination0
  Trying to get property 'items' of non-object

  /home/jdavid/sandboxes/Ably/ably-php/tests/AppStatsTest.php:247
```

Because for some reason the response headers are lowercase. So match the
"Link" header case insensitive.