### PR TITLE
Fix test case in local environment

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -175,7 +175,8 @@ class Http {
 
         if ( $info['http_code'] < 200 || $info['http_code'] >= 300 ) {
             $ablyCode = empty( $decodedBody->error->code ) ? $info['http_code'] * 100 : $decodedBody->error->code * 1;
-            $errorMessage = empty( $decodedBody->error->message ) ? 'cURL request failed' : $decodedBody->error->message;
+            $errorMessage = empty( $decodedBody->error->message ) ? 'cURL request failed'
+                                                                  : $decodedBody->error->message;
 
             throw new AblyRequestException( $errorMessage, $ablyCode, $info['http_code'], $response );
         }

--- a/src/Models/HttpPaginatedResponse.php
+++ b/src/Models/HttpPaginatedResponse.php
@@ -44,7 +44,8 @@ class HttpPaginatedResponse extends PaginatedResult {
      * @param array $headers Headers to be sent with the request
      * @throws AblyRequestException Thrown when the server and all the fallbacks are unreachable
      */
-    public function __construct( \Ably\AblyRest $ably, $model, $cipherParams, $method, $path, $params = [], $headers = [] ) {
+    public function __construct( \Ably\AblyRest $ably, $model, $cipherParams,
+                                 $method, $path, $params = [], $headers = [] ) {
         try {
             parent::__construct( $ably, $model, $cipherParams, $method, $path, $params, $headers );
         } catch (AblyRequestException $ex) {
@@ -83,7 +84,14 @@ class HttpPaginatedResponse extends PaginatedResult {
         foreach($headers as $header) {
             if(!trim($header)) continue;
             list($key, $value) = explode(':', $header, 2);
-            $this->headers[trim($key)] = trim($value);
+            $key = trim($key);
+
+            // Title-Case
+            $key = preg_replace_callback('/\w+/', function ($match) {
+                return ucfirst(strtolower($match[0]));
+            }, $key);
+
+            $this->headers[$key] = trim($value);
         }
     }
 }

--- a/src/Utils/CurlWrapper.php
+++ b/src/Utils/CurlWrapper.php
@@ -20,11 +20,15 @@ class CurlWrapper {
     }
 
     public function setOpt( $handle, $option, $value ) {
-        if ( $option == CURLOPT_URL ) $this->commands[(int) $handle]['url'] = $value;
-        else if ( $option == CURLOPT_POST && $value ) $this->commands[(int) $handle]['command'] .= '-X POST ';
-        else if ( $option == CURLOPT_CUSTOMREQUEST ) $this->commands[(int) $handle]['command'] .= '-X ' . $value . ' ';
-        else if ( $option == CURLOPT_POSTFIELDS ) $this->commands[(int) $handle]['command'] .= '--data "'. str_replace( '"', '\"', $value ) .'" ';
-        else if ( $option == CURLOPT_HTTPHEADER ) {
+        if ( $option == CURLOPT_URL ) {
+            $this->commands[(int) $handle]['url'] = $value;
+        } else if ( $option == CURLOPT_POST && $value ) {
+            $this->commands[(int) $handle]['command'] .= '-X POST ';
+        } else if ( $option == CURLOPT_CUSTOMREQUEST ) {
+            $this->commands[(int) $handle]['command'] .= '-X ' . $value . ' ';
+        } else if ( $option == CURLOPT_POSTFIELDS ) {
+            $this->commands[(int) $handle]['command'] .= '--data "'. str_replace( '"', '\"', $value ) .'" ';
+        } else if ( $option == CURLOPT_HTTPHEADER ) {
             foreach($value as $header) {
                 $this->commands[(int) $handle]['command'] .= '-H "' . str_replace( '"', '\"', $header ).'" ';
             }

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -41,18 +41,23 @@ class HttpTest extends \PHPUnit_Framework_TestCase {
 
         $expectedVersion = '1.1';
 
-        $this->assertArrayHasKey( 'X-Ably-Version', $curlParams[CURLOPT_HTTPHEADER], 'Expected Ably version header in HTTP request' );
-        $this->assertEquals( $expectedVersion, $curlParams[CURLOPT_HTTPHEADER]['X-Ably-Version'], 'Expected Ably version in HTTP header to match AblyRest constant' );
+        $this->assertArrayHasKey( 'X-Ably-Version', $curlParams[CURLOPT_HTTPHEADER],
+                                  'Expected Ably version header in HTTP request' );
+        $this->assertEquals( $expectedVersion, $curlParams[CURLOPT_HTTPHEADER]['X-Ably-Version'],
+                             'Expected Ably version in HTTP header to match AblyRest constant' );
 
-        $this->assertArrayHasKey( 'X-Ably-Lib', $curlParams[CURLOPT_HTTPHEADER], 'Expected Ably lib header in HTTP request' );
-        $this->assertContains( 'php-' . $expectedVersion, $curlParams[CURLOPT_HTTPHEADER]['X-Ably-Lib'], 'Expected Ably lib in HTTP header to match AblyRest constant' );
+        $this->assertArrayHasKey( 'X-Ably-Lib', $curlParams[CURLOPT_HTTPHEADER],
+                                  'Expected Ably lib header in HTTP request' );
+        $this->assertContains( 'php-' . $expectedVersion, $curlParams[CURLOPT_HTTPHEADER]['X-Ably-Lib'],
+                               'Expected Ably lib in HTTP header to match AblyRest constant' );
 
         AblyRest::setLibraryFlavourString( 'test' );
         $ably = new AblyRest( $opts );
         $ably->time(); // make a request
 
         $curlParams = $ably->http->getCurlLastParams();
-        $this->assertContains( 'php-test-' . $expectedVersion, $curlParams[CURLOPT_HTTPHEADER]['X-Ably-Lib'], 'Expected X-Ably-Lib to contain library flavour string' );
+        $this->assertContains( 'php-test-' . $expectedVersion, $curlParams[CURLOPT_HTTPHEADER]['X-Ably-Lib'],
+                               'Expected X-Ably-Lib to contain library flavour string' );
 
         AblyRest::setLibraryFlavourString();
     }
@@ -114,8 +119,10 @@ class HttpTest extends \PHPUnit_Framework_TestCase {
 
         $curlParams = $ably->http->getCurlLastParams();
 
-        $this->assertEquals( 'http://test.test/tokenRequest', $curlParams[CURLOPT_URL], 'Expected URL to match authUrl' );
-        $this->assertEquals( http_build_query($expectedParams), $curlParams[CURLOPT_POSTFIELDS], 'Expected POST params to contain encoded params' );
+        $this->assertEquals( 'http://test.test/tokenRequest', $curlParams[CURLOPT_URL],
+                             'Expected URL to match authUrl' );
+        $this->assertEquals( http_build_query($expectedParams), $curlParams[CURLOPT_POSTFIELDS],
+                             'Expected POST params to contain encoded params' );
     }
 
     /**
@@ -140,17 +147,21 @@ class HttpTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertTrue($res2->success, 'Expected retrieving the message via custom request to succeed');
         $this->assertLessThan(300, $res2->statusCode, 'Expected statusCode < 300');
-        $this->assertArrayHasKey('Content-Type', $res2->headers, 'Expected headers to be an array containing key `Content-Type`');
+        $this->assertArrayHasKey('Content-Type', $res2->headers,
+                                 'Expected headers to be an array containing key `Content-Type`');
         $this->assertEquals(1, count($res2->items), 'Expected to receive 1 message');
-        $this->assertEquals($msg->name, $res2->items[0]->name, 'Expected to receive matching message contents');
+        $this->assertEquals($msg->name, $res2->items[0]->name,
+                            'Expected to receive matching message contents');
 
         $res3 = $ably->request('GET', '/this-does-not-exist');
 
         $this->assertEquals(404, $res3->statusCode, 'Expected statusCode 404');
         $this->assertEquals(40400, $res3->errorCode, 'Expected errorCode 40400');
         $this->assertNotEmpty($res3->errorMessage, 'Expected errorMessage to be set');
-        $this->assertArrayHasKey('X-Ably-Errorcode', $res3->headers, 'Expected X-Ably-Errorcode header to be present');
-        $this->assertArrayHasKey('X-Ably-Errormessage', $res3->headers, 'Expected X-Ably-Errormessage header to be present');
+        $this->assertArrayHasKey('X-Ably-Errorcode', $res3->headers,
+                                 'Expected X-Ably-Errorcode header to be present');
+        $this->assertArrayHasKey('X-Ably-Errormessage', $res3->headers,
+                                 'Expected X-Ably-Errormessage header to be present');
     }
 
     /**


### PR DESCRIPTION
This doesn't show up in CI, but I have this error locally:

```
1) tests\HttpTest::testRequestBasic
Expected headers to be an array containing key `Content-Type`
Failed asserting that an array has the key 'Content-Type'.

/home/jdavid/sandboxes/Ably/ably-php/tests/HttpTest.php:143
```

This PR fixes that unit test.