### PR TITLE
Fix setting X-Ably-* and Accept headers

### DIFF
--- a/src/AblyRest.php
+++ b/src/AblyRest.php
@@ -153,9 +153,9 @@ class AblyRest {
                                      $auth = true ) {
 
         $mergedHeaders = array_merge( [
-            'Accept', 'application/json',
-            'X-Ably-Version' => self::API_VERSION,
-            'X-Ably-Lib' => 'php-' . self::$libFlavour . self::LIB_VERSION,
+            'Accept: application/json',
+            'X-Ably-Version: ' . self::API_VERSION,
+            'X-Ably-Lib: php-' . self::$libFlavour . self::LIB_VERSION,
         ], $headers );
 
         if ( $auth ) { // inject auth headers

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -39,26 +39,19 @@ class HttpTest extends \PHPUnit\Framework\TestCase {
 
         $curlParams = $ably->http->getCurlLastParams();
 
-        $expectedVersion = '1.1';
-
-        $this->assertArrayHasKey( 'X-Ably-Version', $curlParams[CURLOPT_HTTPHEADER],
+        $this->assertContains( 'X-Ably-Version: ' . AblyRest::API_VERSION, $curlParams[CURLOPT_HTTPHEADER],
                                   'Expected Ably version header in HTTP request' );
-        $this->assertEquals( $expectedVersion, $curlParams[CURLOPT_HTTPHEADER]['X-Ably-Version'],
-                             'Expected Ably version in HTTP header to match AblyRest constant' );
 
-        $this->assertArrayHasKey( 'X-Ably-Lib', $curlParams[CURLOPT_HTTPHEADER],
+        $this->assertContains( 'X-Ably-Lib: php-' . AblyRest::LIB_VERSION, $curlParams[CURLOPT_HTTPHEADER],
                                   'Expected Ably lib header in HTTP request' );
-        $this->assertStringContainsString( 'php-' . $expectedVersion,
-                                           $curlParams[CURLOPT_HTTPHEADER]['X-Ably-Lib'],
-                                           'Expected Ably lib in HTTP header to match AblyRest constant' );
 
         AblyRest::setLibraryFlavourString( 'test' );
         $ably = new AblyRest( $opts );
         $ably->time(); // make a request
 
         $curlParams = $ably->http->getCurlLastParams();
-        $this->assertStringContainsString( 'php-test-' . $expectedVersion,
-                                           $curlParams[CURLOPT_HTTPHEADER]['X-Ably-Lib'],
+        $this->assertContains( 'X-Ably-Lib: php-test-' . AblyRest::LIB_VERSION,
+                                           $curlParams[CURLOPT_HTTPHEADER],
                                            'Expected X-Ably-Lib to contain library flavour string' );
 
         AblyRest::setLibraryFlavourString();


### PR DESCRIPTION
The `CURLOPT_HTTPHEADER` value should be an array of `<key>: <val>` strings representing the headers to set.

See https://www.php.net/manual/en/function.curl-setopt.php

Tested manually by running the following program:

```php
require_once __DIR__ . '/vendor/autoload.php';
$settings = array(
  'key'  => '8YPQbA.H2SX3g:************',
  'logLevel' => 4,
);
$app = new \Ably\AblyRest($settings);
$channel = $app->channel('test');
$channel->publish('test', array('handle' => 'x', 'message' => 'y') );
```

And observing the headers being set correctly in the verbose logs:

```
2022-02-22 22:12:15     cURL command:   2022-02-22 22:12:15     curl -X POST -X POST --data "{\"data\":\"{\\"handle\\":\\"x\\",\\"message\\":\\"y\\"}\",\"encoding\":\"json\",\"name\":\"test\"}" -H "Authorization: Basic ****************" -H "Accept: application/json" -H "X-Ably-Version: 1.1" -H "X-Ably-Lib: php-1.1.4" -H "Content-Type: application/json" https://rest.ably.io/channels/test/messages
```

I also confirmed the request was successfully tracked in our internal metrics database.