### PR TITLE
Add case insensitive method to http request

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -94,6 +94,7 @@ class Http {
      * @return array with 'headers' and 'body' fields, body is automatically decoded
      */
     public function request( $method, $url, $headers = [], $params = [] ) {
+        $method = strtoupper($method);
 
         $ch = $this->curl->init($url);
         $this->curl->setOpt( $ch, CURLOPT_CUSTOMREQUEST, $method );


### PR DESCRIPTION
Adds case insensitivity to the public http request - this came from an issue where they we're using a lowercase method:
```php
$client = new Ably\AblyRest('...');
$resp = $client->request('get', '/time', [], '', []);
echo $resp->statusCode; // 400
```
so the curl options never seemed to get set - so returned 400