### PR TITLE
SSL certificate error for PHP CURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you find any compatibility issues, please [do raise an issue](https://github.
 
 ## Known Limitations
 
-Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). However, you can use the [MQTT adapter](https://www.ably.io/documentation/mqtt) to implement [Ably's Realtime](https://www.ably.io/documentation/realtime) features using [PHP](https://github.com/mgdm/Mosquitto-PHP).
+Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). However, you can use the [MQTT adapter](https://www.ably.io/documentation/mqtt) to implement [Ably's Realtime](https://www.ably.io/documentation/realtime) features using [Mosquitto PHP](https://github.com/mgdm/Mosquitto-PHP).
 
 This SDK is *not compatible* with some of the Ably features:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you find any compatibility issues, please [do raise an issue](https://github.
 
 ## Known Limitations
 
-Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). However, you can use the [MQTT adapter](https://www.ably.io/documentation/mqtt) to implement [Ably's Realtime](https://www.ably.io/documentation/realtime) features using Python. 
+Currently, this SDK only supports [Ably REST](https://www.ably.io/documentation/rest). However, you can use the [MQTT adapter](https://www.ably.io/documentation/mqtt) to implement [Ably's Realtime](https://www.ably.io/documentation/realtime) features using [PHP](https://github.com/mgdm/Mosquitto-PHP).
 
 This SDK is *not compatible* with some of the Ably features:
 
@@ -164,6 +164,8 @@ The client library uses the Ably sandbox environment to provision an app and run
     git submodule init
     git submodule update
     ./vendor/bin/phpunit
+
+Note - If there is a issue while running tests [SSL certificate error: unable to get local issuer certificate], please set SSL cert path in `php.ini`.  For more information, follow https://aboutssl.org/fix-ssl-certificate-problem-unable-to-get-local-issuer-certificate/
 
 ## Contributing
 

--- a/tests/factories/TestApp.php
+++ b/tests/factories/TestApp.php
@@ -102,6 +102,10 @@ class TestApp {
     private function request( $mode, $url, $headers = [], $params = '' ) {
         $ch = curl_init($url);
 
+        curl_setopt($ch, CURLOPT_FAILONERROR, true); // Required for HTTP error codes to be reported via call to curl_error($ch)
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2); // Check the existence of a common name and also verify that it matches the hostname provided
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false); // Disable local SSL certificate verification
+
         if ( $mode == 'DELETE') curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, 'DELETE' );
         if ( $mode == 'POST' )  curl_setopt ( $ch, CURLOPT_POST, 1 );
 
@@ -120,6 +124,11 @@ class TestApp {
         } 
 
         $raw = curl_exec($ch);
+
+        if (curl_errno($ch)) {
+            var_dump(curl_error($ch));  // Prints curl request error if exists
+        }
+
         curl_close ($ch);
 
         if ($this->debugRequests) {

--- a/tests/factories/TestApp.php
+++ b/tests/factories/TestApp.php
@@ -103,8 +103,6 @@ class TestApp {
         $ch = curl_init($url);
 
         curl_setopt($ch, CURLOPT_FAILONERROR, true); // Required for HTTP error codes to be reported via call to curl_error($ch)
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2); // Check the existence of a common name and also verify that it matches the hostname provided
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false); // Disable local SSL certificate verification
 
         if ( $mode == 'DELETE') curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, 'DELETE' );
         if ( $mode == 'POST' )  curl_setopt ( $ch, CURLOPT_POST, 1 );


### PR DESCRIPTION
~- Disabled SSL certificate while sending a request to Ably Sandbox.~
~- Fixed error `[SSL certificate error: unable to get local issuer certificate]`~

- Added error reporting for PHP `CURL` specific errors.
- Updated documentation about resolving `[SSL certificate error: unable to get local issuer certificate]`
- Related to #32 
- Related to #38 