### PR TITLE
Change nonAESEncryption algorithm in CryptoTest.php

### DIFF
--- a/tests/CryptoTest.php
+++ b/tests/CryptoTest.php
@@ -94,7 +94,7 @@ class CryptoTest extends \PHPUnit\Framework\TestCase {
             'mode' => 'ecb',
         ]);
 
-
+        print_r(openssl_get_cipher_methods());
         $encrypted = Crypto::encrypt( 'test', $cipherParams );
         $decrypted = Crypto::decrypt( $encrypted, $cipherParams );
         $this->assertNotEquals( $encrypted, $decrypted );

--- a/tests/CryptoTest.php
+++ b/tests/CryptoTest.php
@@ -88,14 +88,15 @@ class CryptoTest extends \PHPUnit\Framework\TestCase {
     }
 
     public function testNonAESEncryptionSupport() {
-        $blowfishParams = Crypto::getDefaultParams( [
+        $cipherParams = Crypto::getDefaultParams( [
             'key' => Crypto::generateRandomKey(128),
-            'algorithm' => 'bf',
+            'algorithm' => 'rc2',
             'mode' => 'ecb',
         ]);
 
-        $encrypted = Crypto::encrypt( 'test', $blowfishParams );
-        $decrypted = Crypto::decrypt( $encrypted, $blowfishParams );
+
+        $encrypted = Crypto::encrypt( 'test', $cipherParams );
+        $decrypted = Crypto::decrypt( $encrypted, $cipherParams );
         $this->assertNotEquals( $encrypted, $decrypted );
         $this->assertEquals( 'test', $decrypted );
 

--- a/tests/CryptoTest.php
+++ b/tests/CryptoTest.php
@@ -90,11 +90,10 @@ class CryptoTest extends \PHPUnit\Framework\TestCase {
     public function testNonAESEncryptionSupport() {
         $cipherParams = Crypto::getDefaultParams( [
             'key' => Crypto::generateRandomKey(128),
-            'algorithm' => 'rc2',
+            'algorithm' => 'sm4',
             'mode' => 'ecb',
         ]);
 
-        print_r(openssl_get_cipher_methods());
         $encrypted = Crypto::encrypt( 'test', $cipherParams );
         $decrypted = Crypto::decrypt( $encrypted, $cipherParams );
         $this->assertNotEquals( $encrypted, $decrypted );


### PR DESCRIPTION
Change algorithm used in `testNonAESEncryptionSupport` from `bf` to `sm4`, reason being is that GitHub had updated their docker image used to run the tests with a newer version of OpenSSL which no longer supports Blowfish, which was previously marked as deprecated.