### PR TITLE
PHP 8.4 - Fixed implicitly nullable parameter issue in BaseMessage Model

### DIFF
--- a/src/Models/BaseMessage.php
+++ b/src/Models/BaseMessage.php
@@ -114,7 +114,7 @@ abstract class BaseMessage {
      * @param stdClass $obj Message-like object
      * @param CipherParams|null $cipherParams
      */
-    public static function fromEncoded( $obj, CipherParams $cipherParams = null ) {
+    public static function fromEncoded( $obj, ?CipherParams $cipherParams = null ) {
         $class = get_called_class();
 
         $msg = new $class();
@@ -138,7 +138,7 @@ abstract class BaseMessage {
      * @param array $objs Array of Message-Like objects
      * @param CipherParams|null $cipherParams
      */
-    public static function fromEncodedArray( $objs, CipherParams $cipherParams = null ) {
+    public static function fromEncodedArray( $objs, ?CipherParams $cipherParams = null ) {
         return array_map(
             function( $obj ) use ($cipherParams) { return static::fromEncoded($obj, $cipherParams); },
             $objs


### PR DESCRIPTION
This fixes the deprecation notice for PHP8.4 regarding implicitly nullable parameters.

https://github.com/ably/ably-php/issues/206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in message creation by allowing nullable cipher parameters in two static methods.
  
- **Bug Fixes**
	- Updated method signatures to accept null values for cipher parameters, improving functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->