### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.github export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
Hello,

This PR add .gitattributes with export-ignore in order to reduce vendor size

More info here:
https://php.watch/articles/composer-gitattributes#export-ignore

With this change, vendor size goes from 668K to 356K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated repository settings to exclude certain files and directories from archive exports. End-users downloading exported archives will no longer see internal configuration, test, or GitHub-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->