### PR TITLE
EDU-2050: Add Laravel-specific package recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Ably aims to support a wide range of platforms. If you experience any compatibil
 
 ---
 
+## Laravel packages
+
+For Laravel applications, consider these framework-integrated alternatives that provide Laravel integration with automatic configuration and native broadcasting support, eliminating the boilerplate setup required when using the raw PHP SDK directly:
+
+* **[Ably Pub/Sub PHP Laravel SDK](https://github.com/ably/ably-php-laravel)** - Laravel integration package with clean facade and dependency injection interface.
+* **[Ably Broadcaster for Laravel](https://github.com/ably/laravel-broadcaster)** - Official Laravel broadcaster for real-time event broadcasting.
+
+---
+
 ## Installation
 
 To get started with your project, install the package:
@@ -43,6 +52,7 @@ To get started with your project, install the package:
 composer require ably/ably-php
 ```
 ---
+
 
 ## Usage
 


### PR DESCRIPTION
This PR:

* Adds a new "Laravel packages" section that provides better integration than using the raw PHP SDK directly.
  * Highlights ably-php-laravel for facade/DI integration
  * Highlights laravel-broadcaster for real-time broadcasting

https://ably.atlassian.net/browse/EDU-2050


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Laravel packages" section highlighting two integration options, with links and brief descriptions.
  * Positioned the new section between "Supported platforms" and "Installation" for easier discovery.
  * Improved README formatting with horizontal rules and spacing for readability.
  * Clarifies integration paths for Laravel users.
  * No changes to code, APIs, or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->