### PR TITLE
Properly handle multiple http status lines.

### DIFF
--- a/src/Models/HttpPaginatedResponse.php
+++ b/src/Models/HttpPaginatedResponse.php
@@ -73,7 +73,7 @@ class HttpPaginatedResponse extends PaginatedResult {
         }
     }
 
-    private function parseHeaders($headers) {
+    private function parseHeaders( $headers ) {
         $headers = explode("\n", $headers);
 
         $this->headers = [];

--- a/src/Models/HttpPaginatedResponse.php
+++ b/src/Models/HttpPaginatedResponse.php
@@ -103,6 +103,7 @@ class HttpPaginatedResponse extends PaginatedResult {
             list($key, $value) = explode(':', $header, 2);
             $key = trim($key);
 
+            // Title-Case
             $key = preg_replace_callback('/\w+/', function ($match) {
                 return ucfirst(strtolower($match[0]));
             }, $key);

--- a/src/Models/HttpPaginatedResponse.php
+++ b/src/Models/HttpPaginatedResponse.php
@@ -96,7 +96,7 @@ class HttpPaginatedResponse extends PaginatedResult {
                 continue;
             }
 
-            if (!str_contains($header, ':')) {
+            if (strpos($header, ':') === false) {
                 continue;
             }
 

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -214,6 +214,71 @@ class HttpTest extends \PHPUnit\Framework\TestCase {
         $res4 = $ably->request('GET', '/get_test_json');
         $this->assertEquals('[]', json_encode($res4->items));
     }
+
+    /**
+     * Test parsing headers from a paginated response with a single block.
+     */
+    public function testHttpPaginatedResponseParseHeadersSingleBlock() {
+        $headers = [
+            'HTTP/1.1 200 OK',
+            'Content-Type: application/json',
+            'X-Ably-Errorcode: 12345',
+            'X-Ably-Errormessage: Test error message',
+            ''
+        ];
+
+        $headers = implode("\n", $headers);
+
+        $ably = new AblyRest([
+            'key' => 'fake.key:totallyFake',
+            'httpClass' => 'tests\HttpMockCustomHeaders',
+        ]);
+
+        $ably->http->setResponseHeaders($headers);
+        $res = $ably->request('GET', '/test');
+
+        $this->assertEquals(200, $res->statusCode, 'Expected status code 200');
+        $this->assertArrayHasKey('Content-Type', $res->headers, 'Expected Content-Type header');
+        $this->assertEquals('application/json', $res->headers['Content-Type']);
+        $this->assertArrayHasKey('X-Ably-Errorcode', $res->headers, 'Expected X-Ably-Errorcode header');
+        $this->assertEquals('12345', $res->headers['X-Ably-Errorcode']);
+    }
+
+    /**
+     * Test parsing headers from a paginated response with multiple blocks.
+     */
+    public function testHttpPaginatedResponseParseHeadersMultipleBlocks() {
+        $headers = [
+            'HTTP/1.1 301 Moved Permanently',
+            'Location: http://example.com/redirect',
+            'Content-Type: text/html',
+            '',
+            'HTTP/1.1 200 OK',
+            'Content-Type: application/json',
+            'X-Custom-Header: custom-value',
+            ''
+        ];
+
+        $headers = implode("\n", $headers);
+
+        $ably = new AblyRest([
+            'key' => 'fake.key:totallyFake',
+            'httpClass' => 'tests\HttpMockCustomHeaders',
+        ]);
+
+        $ably->http->setResponseHeaders($headers);
+        $res = $ably->request('GET', '/test');
+
+        // Should have the status code from the last HTTP block
+        $this->assertEquals(200, $res->statusCode, 'Expected status code 200 from the last HTTP block');
+        // Should have headers from the last HTTP block only
+        $this->assertArrayHasKey('Content-Type', $res->headers, 'Expected Content-Type header');
+        $this->assertEquals('application/json', $res->headers['Content-Type']);
+        $this->assertArrayHasKey('X-Custom-Header', $res->headers, 'Expected X-Custom-Header header');
+        $this->assertEquals('custom-value', $res->headers['X-Custom-Header']);
+        // Should NOT have headers from the first HTTP block
+        $this->assertArrayNotHasKey('Location', $res->headers, 'Expected Location header to be absent from the first block');
+    }
 }
 
 
@@ -288,6 +353,21 @@ class HttpMockReturnData extends Http {
 
     private static function endsWith($haystack, $needle) {
         return substr($haystack, -strlen($needle)) == $needle;
+    }
+}
+
+class HttpMockCustomHeaders extends Http {
+    private $responseHeaders = '';
+
+    public function setResponseHeaders($headers) {
+        $this->responseHeaders = $headers;
+    }
+
+    public function request($method, $url, $headers = [], $params = []) {
+        return [
+            'headers' => $this->responseHeaders,
+            'body' => (object) [],
+        ];
     }
 }
 


### PR DESCRIPTION
This PR handles the case when multiple http header blocks are received from the Ably servers. I stumbled on it today where I received this header response, which resulted in a `Warning: Undefined array key 1` `ErrorException` in our Symfony project.

This was the actual response:

```
HTTP/1.1 100 Continue

HTTP/1.1 201 Created
Content-Type: application/x-msgpack
Transfer-Encoding: chunked
Connection: keep-alive
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: Link,Transfer-Encoding,Content-Length,X-Ably-ErrorCode,X-Ably-ErrorMessage,X-Ably-ServerId,X-Ably-Cluster,Server,X-Amz-Cf-Pop
Vary: Origin
X-Ably-Batch: true
X-Ably-Cluster: production
X-Ably-Serverid: frontdoor.54af.eu-central-1-A.i-093dc4bb86438757d.e91i5D1WATEZbv
Date: Fri, 30 Jan 2026 07:25:38 GMT
X-Cache: Miss from cloudfront
Via: 1.1 b9394c80294503e08bddf2381e55e810.cloudfront.net (CloudFront)
X-Amz-Cf-Pop: AMS1-C1
X-Amz-Cf-Id: [redacted]


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multi-block HTTP response parsing: status codes and headers are now detected per response block and headers reset for subsequent blocks.
  * Skips malformed header lines without key/value pairs.
  * Continues normalizing header keys to Title-Case for consistent display.

* **Tests**
  * Added tests validating single- and multi-block header parsing and status extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->