### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,7 +38,9 @@ jobs:
         run: composer validate
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest ${{ matrix.ignorePlatformReq }}
+        env:
+          IGNORE_PLATFORM_REQ: ${{ matrix.ignorePlatformReq }}
+        run: composer install --prefer-dist --no-progress --no-suggest $IGNORE_PLATFORM_REQ
 
       # the test script is configured in composer.json.
       # see: https://getcomposer.org/doc/articles/scripts.md

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,9 +7,13 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,13 +23,13 @@ jobs:
         ignorePlatformReq: [ '' ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: 'recursive'
           persist-credentials: false
 
       - name: Set up PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php-version }}
           ini-values: error_reporting=E_ALL

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -6,9 +6,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
     uses: ably/features/.github/workflows/sdk-features.yml@main
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
     with:
       repository-name: ably-php
     secrets: inherit


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflows in this repo, addressing findings from a workflow security audit. Changes are split into four commits, one per finding type:
- Disable credential persistence on actions/checkout steps so the default GITHUB_TOKEN is not left in the local git config after checkout.
- Scope each job's permissions explicitly: top-level permissions: {}, with each job granted only the GITHUB_TOKEN scopes it actually needs.
- Move workflow-context expansions (${{ matrix.* }}, step outputs) out of run: shell source and into env: bindings.
- Pin third-party actions to commit SHAs (with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI. The first-party ably/features reusable
workflow intentionally still tracks @main.

No behavioural changes intended — the workflows run the same checks against the same inputs.