### PR TITLE
Prevent curl_close() deprecation on PHP 8.5

### DIFF
--- a/src/Utils/CurlWrapper.php
+++ b/src/Utils/CurlWrapper.php
@@ -44,7 +44,11 @@ class CurlWrapper {
     public function close( $handle ) {
         unset( $this->commands[(int) $handle] );
 
-        return curl_close( $handle );
+        if ( PHP_VERSION_ID < 80000 ) {
+            curl_close( $handle );
+        }
+
+        return null;
     }
 
     public function getInfo( $handle ) {


### PR DESCRIPTION
## Summary

Avoid calling `curl_close()` when running on PHP 8 and above.

Since `curl_close()` has had no effect since PHP 8.0 and is deprecated as of PHP 8.5, this change updates `CurlWrapper::close()` to only call `curl_close()` on PHP versions below 8.0.

## Motivation

This prevents deprecation warnings such as:

> Deprecated: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0

## Testing

- existing test suite should continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup handling for enhanced compatibility with PHP 8.0 and later versions while maintaining support for earlier PHP versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->